### PR TITLE
fix: async validation hanging promise

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
+  "jsxSingleQuote": false,
   "trailingComma": "none"
 }

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
   },
   "lint-staged": {
     "{src,tests}/**/*.{js,jsx,json,scss,ts,tsx}": [
-      "prettier --single-quote --trailingComma none --write"
+      "prettier --write"
     ]
   }
 }


### PR DESCRIPTION
When async validation is debounced and validation is called again, the previous validation promise is not resolved, nor is it rejected. As long as the promise is in progress, the form cannot get out of validating state.

Changed async validation to resolve the promise when timeout is cleared.