### PR TITLE
fix: async validation not canceled

### DIFF
--- a/tests/Field.test.tsx
+++ b/tests/Field.test.tsx
@@ -232,7 +232,7 @@ describe('Component: Field', () => {
       await expect(promise).resolves.toBeUndefined();
 
       await waitFor(() => {
-        expect(renderSpy).toHaveBeenCalledTimes(6);
+        expect(renderSpy).toHaveBeenCalledTimes(5);
       });
 
       expect(screen.getByTestId('errors').innerText).toBeUndefined();


### PR DESCRIPTION
When async validation is started and something changes so validation is called again, the previous validator is not canceled.

Changed async validation timer to depend on check that uses resolvable promise to check if async validation should occur, so the promise can be resolved with false by subsequent calls to cancel previous validations.

Closes #2